### PR TITLE
Fix example .env OIDC vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,9 +57,9 @@ GEOPULSE_OIDC_ENABLED=false
 # 2. Create OAuth 2.0 Client ID
 # 3. Add your callback URL to authorized redirect URIs: http://your-domain:port/api/auth/oidc/callback
 # 4. Copy Client ID and Client Secret below
-GEOPULSE_OIDC_GOOGLE_ENABLED=false
-GEOPULSE_OIDC_GOOGLE_CLIENT_ID=
-GEOPULSE_OIDC_GOOGLE_CLIENT_SECRET=
+GEOPULSE_OIDC_PROVIDER_GOOGLE_ENABLED=false
+GEOPULSE_OIDC_PROVIDER_GOOGLE_CLIENT_ID=
+GEOPULSE_OIDC_PROVIDER_GOOGLE_CLIENT_SECRET=
 
 # ============================================
 # Microsoft OIDC Configuration  
@@ -70,23 +70,23 @@ GEOPULSE_OIDC_GOOGLE_CLIENT_SECRET=
 # 3. Add your callback URL to redirect URIs: http://your-domain:port/api/auth/oidc/callback
 # 4. Create a client secret
 # 5. Copy Application (client) ID and client secret below
-GEOPULSE_OIDC_MICROSOFT_ENABLED=false
-GEOPULSE_OIDC_MICROSOFT_CLIENT_ID=
-GEOPULSE_OIDC_MICROSOFT_CLIENT_SECRET=
+GEOPULSE_OIDC_PROVIDER_MICROSOFT_ENABLED=false
+GEOPULSE_OIDC_PROVIDER_MICROSOFT_CLIENT_ID=
+GEOPULSE_OIDC_PROVIDER_MICROSOFT_CLIENT_SECRET=
 
 # ============================================
 # Generic OIDC Provider Configuration
 # ============================================
 # Use this for Okta, Authentik, PocketId, Keycloak, or any custom OIDC provider
 # You can configure one generic provider at a time
-GEOPULSE_OIDC_GENERIC_ENABLED=false
+GEOPULSE_OIDC_PROVIDER_GENERIC_ENABLED=false
 
 # Display name for the provider (appears on login buttons)
-GEOPULSE_OIDC_GENERIC_NAME=Custom OIDC
+GEOPULSE_OIDC_PROVIDER_GENERIC_NAME=Custom OIDC
 
 # OIDC client credentials
-GEOPULSE_OIDC_GENERIC_CLIENT_ID=
-GEOPULSE_OIDC_GENERIC_CLIENT_SECRET=
+GEOPULSE_OIDC_PROVIDER_GENERIC_CLIENT_ID=
+GEOPULSE_OIDC_PROVIDER_GENERIC_CLIENT_SECRET=
 
 # OIDC discovery URL (usually ends with /.well-known/openid-configuration)
 # Examples:
@@ -94,4 +94,4 @@ GEOPULSE_OIDC_GENERIC_CLIENT_SECRET=
 # - Authentik: https://your-authentik-server/application/o/your-app/.well-known/openid-configuration
 # - Okta: https://your-org.okta.com/.well-known/openid-configuration
 # - PocketId: https://your-pocketid-server/.well-known/openid-configuration
-GEOPULSE_OIDC_GENERIC_DISCOVERY_URL=
+GEOPULSE_OIDC_PROVIDER_GENERIC_DISCOVERY_URL=


### PR DESCRIPTION
Example .env was missing "provider" in the OIDC variables, as per documentation here: https://github.com/lamiskin/geopulse/blob/main/docs/CONFIGURATION.md#configuration-pattern