### PR TITLE
Fix Google Timeline parsing

### DIFF
--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/GpsNativeConfig.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/GpsNativeConfig.java
@@ -66,7 +66,7 @@ import org.github.tess1o.geopulse.gps.model.*;
         GoogleTimelineSemanticSegment.class,
         GoogleTimelineSemanticVisit.class,
         GoogleTimelineSemanticVisitCandidate.class,
-        GoogleTimelineSemanticPlaceLocation.class,
+        GoogleTimelineSemanticLatitudeLongitude.class,
         GoogleTimelineSemanticActivity.class,
         GoogleTimelineSemanticActivityCandidate.class,
         GoogleTimelineSemanticTimelinePath.class,

--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/googletimeline/model/semanticsegments/GoogleTimelineSemanticActivity.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/googletimeline/model/semanticsegments/GoogleTimelineSemanticActivity.java
@@ -12,10 +12,10 @@ import lombok.Data;
 public class GoogleTimelineSemanticActivity {
 
     @JsonProperty("start")
-    private String start; // Format: "50.0506312°, 14.3439906°"
+    private GoogleTimelineSemanticLatitudeLongitude start;
 
     @JsonProperty("end")
-    private String end; // Format: "50.0506312°, 14.3439906°"
+    private GoogleTimelineSemanticLatitudeLongitude end;
 
     @JsonProperty("distanceMeters")
     private Double distanceMeters;

--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/googletimeline/model/semanticsegments/GoogleTimelineSemanticLatitudeLongitude.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/googletimeline/model/semanticsegments/GoogleTimelineSemanticLatitudeLongitude.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
- * Place location with latLng from new Google Timeline format
+ * Location with latLng from new Google Timeline format
  */
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GoogleTimelineSemanticPlaceLocation {
+public class GoogleTimelineSemanticLatitudeLongitude {
 
     @JsonProperty("latLng")
     private String latLng; // Format: "50.0506312°, 14.3439906°"

--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/googletimeline/model/semanticsegments/GoogleTimelineSemanticVisitCandidate.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/googletimeline/model/semanticsegments/GoogleTimelineSemanticVisitCandidate.java
@@ -21,5 +21,5 @@ public class GoogleTimelineSemanticVisitCandidate {
     private Double probability;
 
     @JsonProperty("placeLocation")
-    private GoogleTimelineSemanticPlaceLocation placeLocation;
+    private GoogleTimelineSemanticLatitudeLongitude placeLocation;
 }

--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/googletimeline/util/GoogleTimelineSemanticSegmentsParser.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/googletimeline/util/GoogleTimelineSemanticSegmentsParser.java
@@ -110,8 +110,8 @@ public final class GoogleTimelineSemanticSegmentsParser {
             return;
         }
 
-        double[] startCoords = GoogleTimelineParser.parseGeoString(activity.getStart());
-        double[] endCoords = GoogleTimelineParser.parseGeoString(activity.getEnd());
+        double[] startCoords = GoogleTimelineParser.parseGeoString(activity.getStart().getLatLng());
+        double[] endCoords = GoogleTimelineParser.parseGeoString(activity.getEnd().getLatLng());
 
         double distance = activity.getDistanceMeters() != null ? activity.getDistanceMeters() : 0.0;
 


### PR DESCRIPTION
This pull request fixes the parsing logic to correctly handle latitude and longitude using the `GoogleTimelineSemanticLatitudeLongitude` structure.

Fix #4 