### PR TITLE
Fixed geocoding logic to properly handle when primary geocoder fails

### DIFF
--- a/backend/src/main/java/org/github/tess1o/geopulse/geocoding/adapter/GoogleMapsResponseAdapter.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/geocoding/adapter/GoogleMapsResponseAdapter.java
@@ -2,6 +2,7 @@ package org.github.tess1o.geopulse.geocoding.adapter;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import lombok.extern.slf4j.Slf4j;
+import org.github.tess1o.geopulse.geocoding.exception.GeocodingException;
 import org.github.tess1o.geopulse.geocoding.model.common.FormattableGeocodingResult;
 import org.github.tess1o.geopulse.geocoding.model.common.SimpleFormattableResult;
 import org.github.tess1o.geopulse.geocoding.model.googlemaps.*;
@@ -25,8 +26,9 @@ public class GoogleMapsResponseAdapter implements GeocodingResponseAdapter<Googl
     public FormattableGeocodingResult adapt(GoogleMapsResponse googleResponse, Point requestCoordinates, String providerName) {
 
         if (googleResponse == null || googleResponse.getResults() == null || googleResponse.getResults().isEmpty()) {
-            log.warn("Empty or null Google Maps response");
-            return createFallbackResult(requestCoordinates, providerName);
+            log.warn("Empty or null Google Maps response for coordinates: lon={}, lat={}",
+                    requestCoordinates.getX(), requestCoordinates.getY());
+            throw new GeocodingException("Google Maps returned empty or null response");
         }
 
         // Use the first result (most relevant)
@@ -200,16 +202,4 @@ public class GoogleMapsResponseAdapter implements GeocodingResponseAdapter<Googl
         }
     }
 
-    /**
-     * Create a fallback result when Google Maps response is invalid.
-     */
-    private FormattableGeocodingResult createFallbackResult(Point requestCoordinates, String providerName) {
-        return SimpleFormattableResult.builder()
-                .requestCoordinates(requestCoordinates)
-                .resultCoordinates(requestCoordinates)
-                .formattedDisplayName(String.format("Unknown location at %.6f, %.6f",
-                        requestCoordinates.getY(), requestCoordinates.getX()))
-                .providerName(providerName)
-                .build();
-    }
 }

--- a/backend/src/main/java/org/github/tess1o/geopulse/geocoding/adapter/MapboxResponseAdapter.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/geocoding/adapter/MapboxResponseAdapter.java
@@ -2,6 +2,7 @@ package org.github.tess1o.geopulse.geocoding.adapter;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import lombok.extern.slf4j.Slf4j;
+import org.github.tess1o.geopulse.geocoding.exception.GeocodingException;
 import org.github.tess1o.geopulse.geocoding.model.common.FormattableGeocodingResult;
 import org.github.tess1o.geopulse.geocoding.model.common.SimpleFormattableResult;
 import org.github.tess1o.geopulse.geocoding.model.mapbox.*;
@@ -23,12 +24,13 @@ public class MapboxResponseAdapter implements GeocodingResponseAdapter<MapboxRes
     
     @Override
     public FormattableGeocodingResult adapt(MapboxResponse mapboxResponse, Point requestCoordinates, String providerName) {
-        log.debug("Adapting Mapbox response for coordinates: lon={}, lat={}", 
+        log.debug("Adapting Mapbox response for coordinates: lon={}, lat={}",
                  requestCoordinates.getX(), requestCoordinates.getY());
-        
+
         if (mapboxResponse == null || mapboxResponse.getFeatures() == null || mapboxResponse.getFeatures().isEmpty()) {
-            log.warn("Empty or null Mapbox response");
-            return createFallbackResult(requestCoordinates, providerName);
+            log.warn("Empty or null Mapbox response for coordinates: lon={}, lat={}",
+                    requestCoordinates.getX(), requestCoordinates.getY());
+            throw new GeocodingException("Mapbox returned empty or null response");
         }
         
         // Use the first feature (most relevant)
@@ -170,16 +172,4 @@ public class MapboxResponseAdapter implements GeocodingResponseAdapter<MapboxRes
         }
     }
     
-    /**
-     * Create a fallback result when Mapbox response is invalid.
-     */
-    private FormattableGeocodingResult createFallbackResult(Point requestCoordinates, String providerName) {
-        return SimpleFormattableResult.builder()
-            .requestCoordinates(requestCoordinates)
-            .resultCoordinates(requestCoordinates)
-            .formattedDisplayName(String.format("Unknown location at %.6f, %.6f", 
-                        requestCoordinates.getY(), requestCoordinates.getX()))
-            .providerName(providerName)
-            .build();
-    }
 }

--- a/backend/src/main/java/org/github/tess1o/geopulse/geocoding/adapter/PhotonResponseAdapter.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/geocoding/adapter/PhotonResponseAdapter.java
@@ -2,6 +2,7 @@ package org.github.tess1o.geopulse.geocoding.adapter;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import lombok.extern.slf4j.Slf4j;
+import org.github.tess1o.geopulse.geocoding.exception.GeocodingException;
 import org.github.tess1o.geopulse.geocoding.model.common.FormattableGeocodingResult;
 import org.github.tess1o.geopulse.geocoding.model.common.SimpleFormattableResult;
 import org.github.tess1o.geopulse.geocoding.model.photon.PhotonResponse;
@@ -28,8 +29,9 @@ public class PhotonResponseAdapter implements GeocodingResponseAdapter<PhotonRes
         log.debug("Adapting Photon response: {}", response);
 
         if (response == null || response.getFeatures() == null || response.getFeatures().isEmpty()) {
-            log.warn("Empty or null Photon response");
-            return null;
+            log.warn("Empty or null Photon response for coordinates: lon={}, lat={}",
+                    requestCoordinates.getX(), requestCoordinates.getY());
+            throw new GeocodingException("Photon returned empty or null response");
         }
 
         PhotonResponse.Feature feature = response.getFeatures().get(0);

--- a/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/GeocodingProviderFactory.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/GeocodingProviderFactory.java
@@ -56,7 +56,7 @@ public class GeocodingProviderFactory {
         String fallbackProvider = geocodingConfig.provider().fallback().orElse("");
 
         if (!fallbackProvider.isEmpty() && !fallbackProvider.equalsIgnoreCase(geocodingConfig.provider().primary())) {
-            return primaryResult.onFailure().call(failure -> {
+            return primaryResult.onFailure().recoverWithUni(failure -> {
                 log.warn("Primary provider '{}' failed, trying fallback provider '{}'", geocodingConfig.provider().primary(), fallbackProvider, failure);
                 return callProvider(fallbackProvider, requestCoordinates);
             });

--- a/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/GeocodingServiceImpl.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/GeocodingServiceImpl.java
@@ -55,6 +55,12 @@ public class GeocodingServiceImpl implements GeocodingService {
             FormattableGeocodingResult geocodingResult = providerFactory.reverseGeocode(point)
                     .await().indefinitely();
 
+            // Defensive null check - should never happen with proper adapter/service implementation
+            if (geocodingResult == null) {
+                log.error("Geocoding provider returned null result for coordinates: lon={}, lat={}", longitude, latitude);
+                throw new IllegalStateException("Geocoding provider returned null result");
+            }
+
             log.info("Successfully fetched address from {}: lon={}, lat={}, displayName={}",
                     geocodingResult.getProviderName(), longitude, latitude, geocodingResult.getFormattedDisplayName());
 

--- a/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/MapboxGeocodingService.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/MapboxGeocodingService.java
@@ -72,6 +72,10 @@ public class MapboxGeocodingService {
                     log.debug("Mapbox response received: type={}, firstFeature={}", response.getType(), summary);
                     return adapter.adapt(response, requestCoordinates, getProviderName());
                 })
+                .onItem().ifNull().failWith(() -> {
+                    log.error("Mapbox adapter returned null for coordinates: lon={}, lat={}", longitude, latitude);
+                    return new GeocodingException("Mapbox adapter returned null result");
+                })
                 .onFailure().transform(failure -> {
                     log.error("Mapbox API call failed for coordinates: lon={}, lat={}", longitude, latitude, failure);
                     return new GeocodingException("Mapbox geocoding failed", failure);

--- a/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/NominatimGeocodingService.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/NominatimGeocodingService.java
@@ -65,6 +65,10 @@ public class NominatimGeocodingService {
                     log.debug("Nominatim response received: {}", response.getDisplayName());
                     return adapter.adapt(response, requestCoordinates, getProviderName());
                 })
+                .onItem().ifNull().failWith(() -> {
+                    log.error("Nominatim adapter returned null for coordinates: lon={}, lat={}", longitude, latitude);
+                    return new GeocodingException("Nominatim adapter returned null result");
+                })
                 .onFailure().transform(failure -> {
                     log.error("Nominatim API call failed for coordinates: lon={}, lat={}", longitude, latitude, failure);
                     return new GeocodingException("Nominatim geocoding failed", failure);

--- a/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/PhotonGeocodingService.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/geocoding/service/PhotonGeocodingService.java
@@ -65,6 +65,10 @@ public class PhotonGeocodingService {
                     log.debug("Photon response received: {}", response);
                     return adapter.adapt(response, requestCoordinates, getProviderName());
                 })
+                .onItem().ifNull().failWith(() -> {
+                    log.error("Photon adapter returned null for coordinates: lon={}, lat={}", longitude, latitude);
+                    return new GeocodingException("Photon adapter returned null result");
+                })
                 .onFailure().transform(failure -> {
                     log.error("Photon API call failed for coordinates: lon={}, lat={}", longitude, latitude, failure);
                     return new GeocodingException("Photon geocoding failed", failure);

--- a/backend/src/test/java/org/github/tess1o/geopulse/geocoding/GeocodingFailoverTest.java
+++ b/backend/src/test/java/org/github/tess1o/geopulse/geocoding/GeocodingFailoverTest.java
@@ -1,0 +1,334 @@
+package org.github.tess1o.geopulse.geocoding;
+
+import io.smallrye.mutiny.Uni;
+import org.github.tess1o.geopulse.geocoding.config.GeocodingConfig;
+import org.github.tess1o.geopulse.geocoding.exception.GeocodingException;
+import org.github.tess1o.geopulse.geocoding.model.common.FormattableGeocodingResult;
+import org.github.tess1o.geopulse.geocoding.model.common.SimpleFormattableResult;
+import org.github.tess1o.geopulse.geocoding.service.*;
+import org.github.tess1o.geopulse.shared.geo.GeoUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Point;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit test for geocoding failover mechanism.
+ * Tests that the fallback provider is invoked when the primary provider fails or returns empty results.
+ */
+@ExtendWith(MockitoExtension.class)
+class GeocodingFailoverTest {
+
+    @Mock
+    private NominatimGeocodingService nominatimService;
+
+    @Mock
+    private GoogleMapsGeocodingService googleMapsService;
+
+    @Mock
+    private MapboxGeocodingService mapboxService;
+
+    @Mock
+    private PhotonGeocodingService photonService;
+
+    @Mock
+    private GeocodingConfig geocodingConfig;
+
+    @Mock
+    private GeocodingConfig.Provider provider;
+
+    @Mock
+    private GeocodingConfig.Provider.Nominatim nominatimConfig;
+
+    @Mock
+    private GeocodingConfig.Provider.GoogleMaps googleMapsConfig;
+
+    @Mock
+    private GeocodingConfig.Provider.Mapbox mapboxConfig;
+
+    @Mock
+    private GeocodingConfig.Provider.Photon photonConfig;
+
+    private GeocodingProviderFactory providerFactory;
+
+    private Point testCoordinates;
+
+    @BeforeEach
+    void setUp() {
+        // Setup test coordinates
+        testCoordinates = GeoUtils.createPoint(-73.9857, 40.7484); // Times Square
+
+        // Setup config mocks with lenient() to avoid unnecessary stubbing errors
+        lenient().when(geocodingConfig.provider()).thenReturn(provider);
+        lenient().when(provider.nominatim()).thenReturn(nominatimConfig);
+        lenient().when(provider.googlemaps()).thenReturn(googleMapsConfig);
+        lenient().when(provider.mapbox()).thenReturn(mapboxConfig);
+        lenient().when(provider.photon()).thenReturn(photonConfig);
+
+        // Create factory with mocked services
+        providerFactory = new GeocodingProviderFactory(
+                nominatimService,
+                googleMapsService,
+                mapboxService,
+                photonService,
+                geocodingConfig
+        );
+    }
+
+    @Test
+    void testFailoverTriggersWhenPrimaryProviderFails() {
+        // Given: Photon as primary (fails), Nominatim as fallback (succeeds)
+        when(provider.primary()).thenReturn("photon");
+        when(provider.fallback()).thenReturn(Optional.of("nominatim"));
+
+        when(photonService.isEnabled()).thenReturn(true);
+        when(nominatimService.isEnabled()).thenReturn(true);
+
+        // Primary provider fails with exception
+        when(photonService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().failure(new GeocodingException("Photon API error")));
+
+        // Fallback provider succeeds
+        FormattableGeocodingResult fallbackResult = createMockResult("Times Square", "Nominatim");
+        when(nominatimService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().item(fallbackResult));
+
+        // When: reverse geocode is called
+        FormattableGeocodingResult result = providerFactory.reverseGeocode(testCoordinates)
+                .await().indefinitely();
+
+        // Then: fallback provider should be called and return result
+        assertNotNull(result);
+        assertEquals("Nominatim", result.getProviderName());
+        assertEquals("Times Square", result.getFormattedDisplayName());
+
+        verify(photonService, times(1)).reverseGeocode(testCoordinates);
+        verify(nominatimService, times(1)).reverseGeocode(testCoordinates);
+    }
+
+    @Test
+    void testFailoverTriggersWhenPrimaryProviderReturnsEmptyResults() {
+        // Given: GoogleMaps as primary (returns empty results), Nominatim as fallback
+        when(provider.primary()).thenReturn("googlemaps");
+        when(provider.fallback()).thenReturn(Optional.of("nominatim"));
+
+        when(googleMapsService.isEnabled()).thenReturn(true);
+        when(nominatimService.isEnabled()).thenReturn(true);
+
+        // Primary provider returns null (which gets converted to failure)
+        when(googleMapsService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().failure(new GeocodingException("Google Maps returned empty response")));
+
+        // Fallback provider succeeds
+        FormattableGeocodingResult fallbackResult = createMockResult("Times Square", "Nominatim");
+        when(nominatimService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().item(fallbackResult));
+
+        // When: reverse geocode is called
+        FormattableGeocodingResult result = providerFactory.reverseGeocode(testCoordinates)
+                .await().indefinitely();
+
+        // Then: fallback provider should be called and return result
+        assertNotNull(result);
+        assertEquals("Nominatim", result.getProviderName());
+        assertEquals("Times Square", result.getFormattedDisplayName());
+
+        verify(googleMapsService, times(1)).reverseGeocode(testCoordinates);
+        verify(nominatimService, times(1)).reverseGeocode(testCoordinates);
+    }
+
+    @Test
+    void testNoFailoverWhenPrimaryProviderSucceeds() {
+        // Given: Nominatim as primary (succeeds), GoogleMaps as fallback
+        when(provider.primary()).thenReturn("nominatim");
+        when(provider.fallback()).thenReturn(Optional.of("googlemaps"));
+
+        when(nominatimService.isEnabled()).thenReturn(true);
+        // Don't stub googleMapsService.isEnabled() since it won't be called when primary succeeds
+
+        // Primary provider succeeds
+        FormattableGeocodingResult primaryResult = createMockResult("Times Square", "Nominatim");
+        when(nominatimService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().item(primaryResult));
+
+        // When: reverse geocode is called
+        FormattableGeocodingResult result = providerFactory.reverseGeocode(testCoordinates)
+                .await().indefinitely();
+
+        // Then: only primary provider should be called
+        assertNotNull(result);
+        assertEquals("Nominatim", result.getProviderName());
+        assertEquals("Times Square", result.getFormattedDisplayName());
+
+        verify(nominatimService, times(1)).reverseGeocode(testCoordinates);
+        verify(googleMapsService, never()).reverseGeocode(any());
+    }
+
+    @Test
+    void testFailsWhenBothPrimaryAndFallbackFail() {
+        // Given: Photon as primary (fails), Nominatim as fallback (also fails)
+        when(provider.primary()).thenReturn("photon");
+        when(provider.fallback()).thenReturn(Optional.of("nominatim"));
+
+        when(photonService.isEnabled()).thenReturn(true);
+        when(nominatimService.isEnabled()).thenReturn(true);
+
+        // Both providers fail
+        when(photonService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().failure(new GeocodingException("Photon API error")));
+        when(nominatimService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().failure(new GeocodingException("Nominatim API error")));
+
+        // When/Then: exception should be thrown (GeocodingException)
+        Exception exception = assertThrows(Exception.class, () -> {
+            providerFactory.reverseGeocode(testCoordinates)
+                    .await().indefinitely();
+        });
+
+        // Verify the exception is a GeocodingException (might be wrapped in CompositeException)
+        assertTrue(exception instanceof GeocodingException ||
+                   (exception.getCause() != null && exception.getCause() instanceof GeocodingException),
+                   "Expected GeocodingException but got: " + exception.getClass());
+
+        verify(photonService, times(1)).reverseGeocode(testCoordinates);
+        verify(nominatimService, times(1)).reverseGeocode(testCoordinates);
+    }
+
+    @Test
+    void testNoFailoverWhenFallbackNotConfigured() {
+        // Given: Nominatim as primary (fails), no fallback configured
+        when(provider.primary()).thenReturn("nominatim");
+        when(provider.fallback()).thenReturn(Optional.empty());
+
+        when(nominatimService.isEnabled()).thenReturn(true);
+
+        // Primary provider fails
+        when(nominatimService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().failure(new GeocodingException("Nominatim API error")));
+
+        // When/Then: exception should be thrown without trying fallback
+        Exception exception = assertThrows(Exception.class, () -> {
+            providerFactory.reverseGeocode(testCoordinates)
+                    .await().indefinitely();
+        });
+
+        // Verify the exception is a GeocodingException
+        assertTrue(exception instanceof GeocodingException ||
+                   (exception.getCause() != null && exception.getCause() instanceof GeocodingException),
+                   "Expected GeocodingException but got: " + exception.getClass());
+
+        verify(nominatimService, times(1)).reverseGeocode(testCoordinates);
+        verify(googleMapsService, never()).reverseGeocode(any());
+        verify(mapboxService, never()).reverseGeocode(any());
+        verify(photonService, never()).reverseGeocode(any());
+    }
+
+    @Test
+    void testNoFailoverWhenFallbackSameAsPrimary() {
+        // Given: Nominatim as both primary and fallback (same provider)
+        when(provider.primary()).thenReturn("nominatim");
+        when(provider.fallback()).thenReturn(Optional.of("nominatim"));
+
+        when(nominatimService.isEnabled()).thenReturn(true);
+
+        // Primary provider fails
+        when(nominatimService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().failure(new GeocodingException("Nominatim API error")));
+
+        // When/Then: exception should be thrown without trying fallback
+        Exception exception = assertThrows(Exception.class, () -> {
+            providerFactory.reverseGeocode(testCoordinates)
+                    .await().indefinitely();
+        });
+
+        // Verify the exception is a GeocodingException
+        assertTrue(exception instanceof GeocodingException ||
+                   (exception.getCause() != null && exception.getCause() instanceof GeocodingException),
+                   "Expected GeocodingException but got: " + exception.getClass());
+
+        // Should only be called once (primary), not twice (primary + fallback)
+        verify(nominatimService, times(1)).reverseGeocode(testCoordinates);
+    }
+
+    @Test
+    void testFailoverWithDisabledFallbackProvider() {
+        // Given: Photon as primary (fails), GoogleMaps as fallback (disabled)
+        when(provider.primary()).thenReturn("photon");
+        when(provider.fallback()).thenReturn(Optional.of("googlemaps"));
+
+        when(photonService.isEnabled()).thenReturn(true);
+        when(googleMapsService.isEnabled()).thenReturn(false); // Fallback disabled
+
+        // Primary provider fails
+        when(photonService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().failure(new GeocodingException("Photon API error")));
+
+        // When/Then: exception should be thrown (fallback won't work because it's disabled)
+        Exception exception = assertThrows(Exception.class, () -> {
+            providerFactory.reverseGeocode(testCoordinates)
+                    .await().indefinitely();
+        });
+
+        // Verify the exception is a GeocodingException
+        assertTrue(exception instanceof GeocodingException ||
+                   (exception.getCause() != null && exception.getCause() instanceof GeocodingException),
+                   "Expected GeocodingException but got: " + exception.getClass());
+
+        verify(photonService, times(1)).reverseGeocode(testCoordinates);
+        // GoogleMaps reverseGeocode shouldn't be called, but isEnabled() is checked
+        verify(googleMapsService, never()).reverseGeocode(any());
+    }
+
+    @Test
+    void testMultipleProviderFailoverChain() {
+        // Given: Mapbox as primary (fails), Nominatim as fallback (succeeds)
+        when(provider.primary()).thenReturn("mapbox");
+        when(provider.fallback()).thenReturn(Optional.of("nominatim"));
+
+        when(mapboxService.isEnabled()).thenReturn(true);
+        when(nominatimService.isEnabled()).thenReturn(true);
+
+        // Primary fails with empty results
+        when(mapboxService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().failure(new GeocodingException("Mapbox returned empty response")));
+
+        // Fallback succeeds
+        FormattableGeocodingResult fallbackResult = createMockResult("Times Square", "Nominatim");
+        when(nominatimService.reverseGeocode(testCoordinates))
+                .thenReturn(Uni.createFrom().item(fallbackResult));
+
+        // When: reverse geocode is called
+        FormattableGeocodingResult result = providerFactory.reverseGeocode(testCoordinates)
+                .await().indefinitely();
+
+        // Then: fallback provider should be used
+        assertNotNull(result);
+        assertEquals("Nominatim", result.getProviderName());
+        assertEquals("Times Square", result.getFormattedDisplayName());
+
+        verify(mapboxService, times(1)).reverseGeocode(testCoordinates);
+        verify(nominatimService, times(1)).reverseGeocode(testCoordinates);
+    }
+
+    /**
+     * Helper method to create a mock geocoding result
+     */
+    private FormattableGeocodingResult createMockResult(String displayName, String providerName) {
+        return SimpleFormattableResult.builder()
+                .requestCoordinates(testCoordinates)
+                .resultCoordinates(testCoordinates)
+                .formattedDisplayName(displayName)
+                .providerName(providerName)
+                .city("New York")
+                .country("United States")
+                .build();
+    }
+}


### PR DESCRIPTION
Fixed all geocoders to properly handle cases when primary fails and failover (if configured) should be executed. Added unit tests to verify this.