### PR TITLE
Update TimelinePage.vue - Fix right-pane height goes beyond viewport

### DIFF
--- a/frontend/src/views/app/TimelinePage.vue
+++ b/frontend/src/views/app/TimelinePage.vue
@@ -508,6 +508,7 @@ watch(pathData, () => {
   .right-pane {
     flex: 1;
     width: 100%;
+    min-height: 0;
     margin-top: 0;
     overflow-y: auto !important;
   }


### PR DESCRIPTION
Fix for Timeline pane goes beyond viewport of small smartphone screen, blocking the last event's text
<img width="377" height="692" alt="Screenshot From 2026-01-13 21-33-06" src="https://github.com/user-attachments/assets/7bcd67e5-038a-495e-9be0-a1af3d7e02e6" />

