### PR TITLE
feat: Configurable termination grace period & lifecycle

### DIFF
--- a/helm/geopulse/templates/backend/deployment.yaml
+++ b/helm/geopulse/templates/backend/deployment.yaml
@@ -104,8 +104,8 @@ spec:
               readOnly: true
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
-      {{- with .Values.backend.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ . }}
+      {{- if ne .Values.backend.terminationGracePeriodSeconds nil }}
+      terminationGracePeriodSeconds: {{ .Values.backend.terminationGracePeriodSeconds }}
       {{- end }}
       volumes:
         - name: keys

--- a/helm/geopulse/templates/backend/deployment.yaml
+++ b/helm/geopulse/templates/backend/deployment.yaml
@@ -94,12 +94,19 @@ spec:
             timeoutSeconds: {{ .Values.backend.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.backend.readinessProbe.failureThreshold }}
           {{- end }}
+          {{- with .Values.backend.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: keys
               mountPath: /app/keys
               readOnly: true
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
+      {{- with .Values.backend.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       volumes:
         - name: keys
           {{- if .Values.keygen.persistence.enabled }}

--- a/helm/geopulse/values.yaml
+++ b/helm/geopulse/values.yaml
@@ -51,6 +51,19 @@ backend:
     timeoutSeconds: 3
     failureThreshold: 3
 
+  # Graceful shutdown configuration.
+  # terminationGracePeriodSeconds should be longer than the preStop sleep so
+  # Kubernetes can let in-flight requests drain before SIGTERM lands.
+  # Leave both unset to fall back to Kubernetes defaults.
+  # Example:
+  #   terminationGracePeriodSeconds: 60
+  #   lifecycle:
+  #     preStop:
+  #       exec:
+  #         command: ["sh", "-c", "sleep 15"]
+  terminationGracePeriodSeconds: null
+  lifecycle: {}
+
   # Security context
   # Both JVM and native images support running as non-root with arbitrary UIDs
   # Using fsGroup: 0 (root group) enables OpenShift compatibility


### PR DESCRIPTION
With bursty workloads, like receiving many thousands of points in less than a minute, Quarkus can get overwhelmed and stopped responding to health probes in a timely manner. This in turn causes Kubelet to send SIGTERM, triggering a shutdown, which can take a long time to complete.

In my case, with a `1000m` vCPU limit, Quarkus shutdown took 26.8s and at the end there were still ~160 busy executor threads.

This change makes it possible to configure the grace period as well setting a custom lifecycle. Ultimately, the problem is resource contention and I increased the limits in my own environment, but this change will help more generally in resource constrained environments.