### PR TITLE
Reject Overland points with no accuracy value

### DIFF
--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/overland/model/Properties.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/integrations/overland/model/Properties.java
@@ -22,9 +22,9 @@ public class Properties {
     @JsonProperty("speed_accuracy")
     private double speedAccuracy;
     @JsonProperty("horizontal_accuracy")
-    private double horizontalAccuracy;
+    private Double horizontalAccuracy;
     @JsonProperty("vertical_accuracy")
-    private double verticalAccuracy;
+    private Double verticalAccuracy;
     private String wifi;
     private int course;
     private int altitude;

--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/mapper/GpsPointMapper.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/mapper/GpsPointMapper.java
@@ -77,7 +77,7 @@ public class GpsPointMapper {
         entity.setUser(userId);
         entity.setCoordinates(GeoUtils.createPoint(message.getGeometry().getLongitude(), message.getGeometry().getLatitude()));
         entity.setTimestamp(message.getProperties().getTimestamp());
-        entity.setAccuracy(message.getProperties().getHorizontalAccuracy());
+        entity.setAccuracy(message.getProperties().getVerticalAccuracy());
         // Convert speed from m/s to km/h for consistent storage (Dawarich sends m/s)
         Double speedMs = message.getProperties().getSpeed();
         entity.setVelocity(speedMs != null ? speedMs * 3.6 : null);

--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/mapper/GpsPointMapper.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/mapper/GpsPointMapper.java
@@ -59,7 +59,7 @@ public class GpsPointMapper {
         entity.setUser(userId);
         entity.setCoordinates(GeoUtils.createPoint(message.getGeometry().getCoordinates()[0], message.getGeometry().getCoordinates()[1]));
         entity.setTimestamp(message.getProperties().getTimestamp());
-        entity.setAccuracy(message.getProperties().getVerticalAccuracy());
+        entity.setAccuracy(message.getProperties().getHorizontalAccuracy());
         entity.setBattery(message.getProperties().getBatteryLevel() * 100);
         // Convert speed from m/s to km/h for consistent storage (Overland sends m/s)
         Double speedMs = message.getProperties().getSpeed();
@@ -77,7 +77,7 @@ public class GpsPointMapper {
         entity.setUser(userId);
         entity.setCoordinates(GeoUtils.createPoint(message.getGeometry().getLongitude(), message.getGeometry().getLatitude()));
         entity.setTimestamp(message.getProperties().getTimestamp());
-        entity.setAccuracy(message.getProperties().getVerticalAccuracy());
+        entity.setAccuracy(message.getProperties().getHorizontalAccuracy());
         // Convert speed from m/s to km/h for consistent storage (Dawarich sends m/s)
         Double speedMs = message.getProperties().getSpeed();
         entity.setVelocity(speedMs != null ? speedMs * 3.6 : null);

--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/service/filter/GpsDataFilteringService.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/service/filter/GpsDataFilteringService.java
@@ -5,6 +5,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import lombok.extern.slf4j.Slf4j;
 import org.github.tess1o.geopulse.gps.model.GpsPointEntity;
 import org.github.tess1o.geopulse.gpssource.model.GpsSourceConfigEntity;
+import org.github.tess1o.geopulse.shared.gps.GpsSourceType;
 
 /**
  * Service for filtering GPS data based on per-source configuration.
@@ -50,8 +51,13 @@ public class GpsDataFilteringService {
         Double speedKmh = entity.getVelocity(); // Already in km/h from mapper
 
         // Check accuracy threshold
-        if (config.getMaxAllowedAccuracy() != null && accuracy != null) {
-            if (accuracy > config.getMaxAllowedAccuracy()) {
+        if (config.getMaxAllowedAccuracy() != null) {
+            if (accuracy == null && entity.getSourceType() == GpsSourceType.OVERLAND) {
+                log.info("Rejected GPS point for user {} source {} - no accuracy value (maxAllowedAccuracy is {}m)",
+                        entity.getUser().getId(), entity.getSourceType(), config.getMaxAllowedAccuracy());
+                return GpsFilterResult.rejectedByMissingAccuracy(config.getMaxAllowedAccuracy());
+            }
+            if (accuracy != null && accuracy > config.getMaxAllowedAccuracy()) {
                 log.info("Rejected GPS point for user {} source {} - accuracy {}m exceeds limit {}m",
                         entity.getUser().getId(), entity.getSourceType(), accuracy, config.getMaxAllowedAccuracy());
                 return GpsFilterResult.rejectedByAccuracy(accuracy, config.getMaxAllowedAccuracy());

--- a/backend/src/main/java/org/github/tess1o/geopulse/gps/service/filter/GpsFilterResult.java
+++ b/backend/src/main/java/org/github/tess1o/geopulse/gps/service/filter/GpsFilterResult.java
@@ -26,6 +26,17 @@ public class GpsFilterResult {
     }
 
     /**
+     * Create a result indicating the GPS point was rejected because accuracy is absent
+     * and a maximum accuracy threshold is configured.
+     *
+     * @param threshold The maximum allowed accuracy in meters
+     */
+    public static GpsFilterResult rejectedByMissingAccuracy(int threshold) {
+        String reason = String.format("No accuracy value provided; threshold is %dm", threshold);
+        return new GpsFilterResult(false, reason);
+    }
+
+    /**
      * Create a result indicating the GPS point was rejected due to poor accuracy
      *
      * @param actual    The actual accuracy value in meters

--- a/backend/src/test/java/org/github/tess1o/geopulse/gps/service/filter/GpsDataFilteringServiceTest.java
+++ b/backend/src/test/java/org/github/tess1o/geopulse/gps/service/filter/GpsDataFilteringServiceTest.java
@@ -96,6 +96,18 @@ class GpsDataFilteringServiceTest {
         assertTrue(result.isAccepted());
     }
     @Test
+    void testAccuracyFilter_Overland_RejectsNullAccuracy() {
+        // Given: Filtering enabled with a threshold configured
+        config.setFilterInaccurateData(true);
+        config.setMaxAllowedAccuracy(100);
+        // When: Overland point with no accuracy value
+        GpsPointEntity entity = createGpsPoint(null, 50.0, GpsSourceType.OVERLAND);
+        GpsFilterResult result = filteringService.filter(entity, config);
+        // Then: Point is rejected, unlike other sources
+        assertTrue(result.isRejected());
+        assertTrue(result.getRejectionReason().toLowerCase(Locale.ROOT).contains("accuracy"));
+    }
+    @Test
     void testSpeedFilter_AcceptsPointUnderThreshold() {
         // Given: Filtering enabled with 250 km/h threshold
         config.setFilterInaccurateData(true);
@@ -257,9 +269,12 @@ class GpsDataFilteringServiceTest {
      * Helper method to create a GPS point entity for testing
      */
     private GpsPointEntity createGpsPoint(Double accuracy, Double speedKmh) {
+        return createGpsPoint(accuracy, speedKmh, GpsSourceType.OWNTRACKS);
+    }
+    private GpsPointEntity createGpsPoint(Double accuracy, Double speedKmh, GpsSourceType sourceType) {
         GpsPointEntity entity = new GpsPointEntity();
         entity.setUser(testUser);
-        entity.setSourceType(GpsSourceType.OWNTRACKS);
+        entity.setSourceType(sourceType);
         entity.setAccuracy(accuracy);
         entity.setVelocity(speedKmh); // Already in km/h
         entity.setTimestamp(Instant.now());


### PR DESCRIPTION
I noticed that Overland sometimes resends a stale/cached location at the current time. This is an upstream issue for sure, but these points conveniently come with no accuracy value at all. The existing per-source accuracy filter (the min accuracy setting) doesn't catch this, since a missing value was just treated as "unknown" and let through.

There were a couple of things going on. Overland's accuracy fields were primitive doubles, so when the field is missing from the JSON it silently became 0.0 instead of actually being missing, which looks like a perfect GPS fix to the filter. I changed those to boxed Double so missing actually means missing. 

I also noticed the filter was reading vertical_accuracy for the accuracy check, but that's altitude precision, not position precision, so I switched it to horizontal_accuracy, which felt like the more intuitive field to use here. 

On top of that, I added a check so that if a point comes from Overland with no accuracy at all, and you've already set a max accuracy threshold, it gets rejected.

I scoped the rejection to Overland only for now, since that's where I've actually seen this happen, and I didn't want to change behaviour for other sources without a reason to.

Happy to make this a separate toggle if you'd rather have it opt-in, but rejecting points with no accuracy when a min accuracy is set seemed reasonable to me.