### PR TITLE
feat(helm): add extraVolumes / extraVolumeMounts to backend, frontend…

### DIFF
--- a/helm/geopulse/README.md
+++ b/helm/geopulse/README.md
@@ -83,6 +83,26 @@ backend:
           key: password
 ```
 
+### Extra Volumes
+
+`backend`, `frontend` and `mosquitto` each accept `extraVolumes` and `extraVolumeMounts`, which are appended to the volumes the chart already defines.
+
+The backend only mounts the generated JWT / AI keys, so any other storage it has to read or write has to be attached this way. A common case is a directory of GPX or Google Takeout files produced elsewhere, made available to the backend for import:
+
+```yaml
+backend:
+  extraVolumes:
+    - name: import
+      nfs:
+        server: nas.example.com
+        path: /exports/geopulse-import
+  extraVolumeMounts:
+    - name: import
+      mountPath: /data/geopulse-import
+```
+
+A mount is only visible to the container it is declared on, so a volume shared between the backend and the frontend has to be listed under both.
+
 ### Most Common Parameters
 
 | Parameter | Description | Default |

--- a/helm/geopulse/templates/backend/deployment.yaml
+++ b/helm/geopulse/templates/backend/deployment.yaml
@@ -110,6 +110,9 @@ spec:
             - name: keys
               mountPath: /app/keys
               readOnly: true
+            {{- with .Values.backend.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
       {{- if ne .Values.backend.terminationGracePeriodSeconds nil }}
@@ -127,6 +130,9 @@ spec:
           configMap:
             name: {{ include "geopulse.fullname" . }}-keygen-script
             defaultMode: 0755
+        {{- with .Values.backend.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/geopulse/templates/frontend/deployment.yaml
+++ b/helm/geopulse/templates/frontend/deployment.yaml
@@ -81,8 +81,16 @@ spec:
             timeoutSeconds: {{ .Values.frontend.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.frontend.readinessProbe.failureThreshold }}
           {{- end }}
+          {{- with .Values.frontend.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
+      {{- with .Values.frontend.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/geopulse/templates/mosquitto/deployment.yaml
+++ b/helm/geopulse/templates/mosquitto/deployment.yaml
@@ -77,6 +77,9 @@ spec:
               mountPath: /mosquitto/data
             - name: logs
               mountPath: /mosquitto/log
+            {{- with .Values.mosquitto.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.mosquitto.resources | nindent 12 }}
       volumes:
@@ -101,6 +104,9 @@ spec:
           emptyDir: {}
         - name: logs
           emptyDir: {}
+        {{- end }}
+        {{- with .Values.mosquitto.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.mosquitto.nodeSelector }}
       nodeSelector:

--- a/helm/geopulse/values.yaml
+++ b/helm/geopulse/values.yaml
@@ -85,6 +85,21 @@ backend:
   #         name: my-extra-secret
   extraEnvFrom: []
 
+  # Additional volumes / volume mounts, appended to the ones the chart sets.
+  # The chart only mounts the generated keys, so anything else the backend needs
+  # to read or write - an import directory, a CA bundle - has to come from here.
+  # Example:
+  #   extraVolumes:
+  #     - name: import
+  #       nfs:
+  #         server: nas.example.com
+  #         path: /exports/geopulse-import
+  #   extraVolumeMounts:
+  #     - name: import
+  #       mountPath: /data/geopulse-import
+  extraVolumes: []
+  extraVolumeMounts: []
+
   # Security context
   # Both JVM and native images support running as non-root with arbitrary UIDs
   # Using fsGroup: 0 (root group) enables OpenShift compatibility
@@ -125,6 +140,10 @@ frontend:
   # Additional environment variables / envFrom sources. See backend.extraEnv.
   extraEnv: []
   extraEnvFrom: []
+
+  # Additional volumes / volume mounts. See backend.extraVolumes.
+  extraVolumes: []
+  extraVolumeMounts: []
 
   resources:
     limits:
@@ -296,6 +315,10 @@ mosquitto:
   # Additional environment variables / envFrom sources. See backend.extraEnv.
   extraEnv: []
   extraEnvFrom: []
+
+  # Additional volumes / volume mounts. See backend.extraVolumes.
+  extraVolumes: []
+  extraVolumeMounts: []
 
   # Persistence configuration
   persistence:


### PR DESCRIPTION
… and mosquito

This is similar to yesterdays [PR 564](https://github.com/tess1o/geopulse/pull/564), but for volumes/volumeMounts instead of envs.

Each deployment's volumes are fixed by the chart - the backend mounts only the generated JWT/AI keys, the frontend mounts nothing, and mosquitto mounts its entrypoint plus the three persistence volumes. There is no way to attach anything else, so storage the chart does not own cannot be reached from the containers.

I want to use the drop folder feature to import GPX files from a different sync job produced elsewhere.  This location has to be readable by the backend, and today the only way to get them mounted is a helm post-renderer patch the rendered Deployment.

This commit adds `extraVolumes` and `extraVolumeMounts` to the three deployments, appended after the chart's own entries. The frontend previously rendered neither block, so both are emitted only when the corresponding value is non-empty. Rendering with default values is unchanged.