### PR TITLE
Add deployment strategy configuration to backend

### DIFF
--- a/helm/geopulse/templates/backend/deployment.yaml
+++ b/helm/geopulse/templates/backend/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "geopulse.backend.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.backend.strategy }}
+  strategy:
+    {{- toYaml .Values.backend.strategy | nindent 4 }}
+  {{- end }}
   replicas: {{ .Values.backend.replicaCount }}
   selector:
     matchLabels:

--- a/helm/geopulse/values.yaml
+++ b/helm/geopulse/values.yaml
@@ -11,6 +11,9 @@ global:
 
 # Backend configuration
 backend:
+  strategy:
+    type: RollingUpdate  # or Recreate
+
   image:
     repository: tess1o/geopulse-backend
     tag: 1.37.0-native


### PR DESCRIPTION
Add option to configure the deployment strategy of the backend. With the default RollingUpdate strategy, rollouts might get stuck in case of RWO PVs as only one backend pod can be running at any given time.